### PR TITLE
Keep everything within viewport

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0>
-    <style> body {padding: 0; margin: 0; text-align: center}
+    <style> body {padding: 0; margin: 0; text-align: center; overflow: hidden;}
       canvas { display: inline; }
     </style>
     <script src="lib/p5.js"></script>


### PR DESCRIPTION
![prideflag](https://user-images.githubusercontent.com/13908849/50877324-1d676d00-13b0-11e9-9ad9-e34960082bd2.png)
On firefox, it triggers some scrollbars which don't look very nice. This seemed like the easiest and most non-intrusive way to fix it. Interesting idea by the way!